### PR TITLE
mark began as false during close methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,7 @@ const LCD = class LCD {
         if (err) {
           rej(err);
         } else {
+          this._began = false;
           res();
         }
       });
@@ -176,6 +177,7 @@ const LCD = class LCD {
     if (!this._began) {
       throw new Error('The LCD is not initialized! Call begin() before using any method!');
     }
+    this._began = false;
     return this._i2c.closeSync();
   }
 
@@ -184,7 +186,10 @@ const LCD = class LCD {
       cb(new Error('The LCD is not initialized! Call begin() before using any method!'));
       return;
     }
-    this._i2c.close(cb);
+    this._i2c.close(err => {
+      if(!err) this._began = false;
+      cb(err)
+    });
   }
 
   clear() {


### PR DESCRIPTION
### Expected behaviour
I'd like `lcd.began` to return `false` after I call any of the `close` methods. 

### Why
So I can use `lcd.began` as a flag as to whether the i2c bus is still open, even after calling a `close` method.

### Use Case
If the i2c bus fails at some point, I'd like to call `lcd.close()` (or sync version) to mark the connection as closed, then retry connecting again. I'd like the `lcd.began` property to reflect whether the i2c connection has been closed.